### PR TITLE
Add the ability to create scene object collection bookmarks.

### DIFF
--- a/Assets/Bookmark4Unity/CHANGELOG.md
+++ b/Assets/Bookmark4Unity/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## v1.1.3 (2023-01-15)
+
+### Features
+
+- Added scene object collection bookmarking.
+  - When pinning multiple scene objects, you will be asked to either create a collection of scene objects or add scene object bookmarks individually.
+- Guid components will not be removed automatically when un-pinning scene object bookmarks to avoid making bookmark collections invalid.
+  - If you want to remove all guid components in loaded scenes, use `Bookmark4Unity Window → Clear → All Guid Components Attached`. Note that removing guid components will make scene object bookmarks invalid.
+
+### Bugfix
+
+- Fix a typo in scene objects editor dialogue.
+
 ## v1.1.2 (2023-01-10)
 
 ### Features

--- a/Assets/Bookmark4Unity/Editor/SceneObjectCollectionListView.cs
+++ b/Assets/Bookmark4Unity/Editor/SceneObjectCollectionListView.cs
@@ -1,0 +1,225 @@
+namespace Bookmark4Unity.Editor
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Bookmark4Unity.Guid;
+    using UnityEditor;
+    using UnityEngine;
+    using UnityEngine.UIElements;
+
+    [Serializable]
+    public class SceneObjectCollection
+    {
+        public string name;
+        public string scene;
+        public List<GuidData> datas;
+
+        public SceneObjectCollection(string name, string scene, List<GuidData> datas)
+        {
+            this.name = name;
+            this.scene = scene;
+            this.datas = datas;
+        }
+    }
+
+    public class SceneObjectReferenceCollection
+    {
+        public string name;
+        public string scene;
+        public List<GuidReference> references;
+
+        public SceneObjectReferenceCollection(string name, string scene, List<GuidReference> references)
+        {
+            this.name = name;
+            this.scene = scene;
+            this.references = references;
+        }
+
+        public SceneObjectReferenceCollection(SceneObjectCollection collection)
+        {
+            this.name = collection.name;
+            this.scene = collection.scene;
+            this.references = collection.datas.Select(data => new GuidReference(data)).ToList();
+        }
+
+        public SceneObjectCollection ToData()
+        {
+            return new SceneObjectCollection(
+                name,
+                scene,
+                references.Select(reference => reference.ToData()).ToList()
+            );
+        }
+    }
+
+    public class SceneObjectCollectionListView
+    {
+        public event Action ChangeEvent;
+        public List<SceneObjectReferenceCollection> Data { get; private set; }
+        public ListView DataListView { get; private set; }
+        public const int ItemHeight = 15;
+        public bool IsEmpty => Data.Count < 1;
+        public Dictionary<int, EventCallback<ClickEvent>> pingActions = new();
+        public Dictionary<int, EventCallback<ClickEvent>> focusActions = new();
+        public Dictionary<int, EventCallback<ClickEvent>> delActions = new();
+        public Dictionary<int, EventCallback<PointerLeaveEvent>> dragActions = new();
+
+        public SceneObjectCollectionListView(List<SceneObjectReferenceCollection> data, VisualTreeAsset btnAsset)
+        {
+            Data = data;
+            DataListView = new(Data, ItemHeight, () =>
+            {
+                return btnAsset.Instantiate();
+            },
+            (item, i) =>
+            {
+                var icon = item.Q<Button>("Icon");
+                var btn = item.Q<Button>("Btn");
+                var focus = item.Q<Button>("Focus");
+                var del = item.Q<Button>("Del");
+                var data = Data[i];
+                var index = i; // save value for lambda functions
+                icon.style.backgroundImage = Background.FromTexture2D(
+                    data.references.Any(reference => reference.gameObject is null) ?
+                    EditorGUIUtility.IconContent("console.warnicon").image as Texture2D :
+                    EditorGUIUtility.IconContent("d_LODGroup Icon").image as Texture2D);
+                focus.style.backgroundImage = Background.FromTexture2D(SceneViewBookmarkManager.SceneViewBookmarkIcon);
+                del.style.backgroundImage = Background.FromTexture2D(SceneViewBookmarkManager.SceneViewEmptyIcon);
+                btn.text = data.name;
+
+                // ping
+                if (pingActions.ContainsKey(i)) btn.UnregisterCallback<ClickEvent>(pingActions[i]);
+                pingActions[i] = evt => Ping(index);
+                btn.RegisterCallback<ClickEvent>(pingActions[i]);
+                btn.tooltip = $"Select scene objects collection \"{data.name}\"";
+
+                // focus
+                if (focusActions.ContainsKey(i)) focus.UnregisterCallback<ClickEvent>(focusActions[i]);
+                focusActions[i] = evt => Focus(index);
+                focus.RegisterCallback<ClickEvent>(focusActions[i]);
+                focus.tooltip = $"Focus on scene objects collection \"{data.name}\"";
+
+                // del
+                if (delActions.ContainsKey(i)) del.UnregisterCallback<ClickEvent>(delActions[i]);
+                delActions[i] = evt => Remove(index);
+                del.RegisterCallback<ClickEvent>(delActions[i]);
+                del.tooltip = $"Unpin scene objects collection \"{data.name}\"";
+
+                // drag
+                if (dragActions.ContainsKey(i)) btn.UnregisterCallback<PointerLeaveEvent>(dragActions[i]);
+                dragActions[i] = evt => OnDrag(index);
+                btn.RegisterCallback<PointerLeaveEvent>(dragActions[i]);
+            })
+            {
+                reorderable = true,
+                showBorder = false
+            };
+
+            DataListView.style.flexGrow = 1f; // Fills the window
+            DataListView.style.display = IsEmpty ? DisplayStyle.None : DisplayStyle.Flex;
+        }
+
+        public bool Add(SceneObjectReferenceCollection data)
+        {
+            if (Data.Contains(data)) return false;
+            Data.Add(data);
+            DataListView.Rebuild();
+            ChangeEvent?.Invoke();
+            DataListView.style.display = DisplayStyle.Flex;
+            return true;
+        }
+
+        public void Ping(int index)
+        {
+            if (Data[index].references.Any(reference => reference.gameObject is null))
+            {
+                if (EditorUtility.DisplayDialog(Data[index].name, "Selected game object collection contains invalid references, remove it from list?", "Yes", "No"))
+                {
+                    Remove(index);
+                }
+            }
+            else
+            {
+                Selection.objects = Data[index].references.Select(reference => reference.gameObject).ToArray();
+            }
+        }
+
+        public void Focus(int index)
+        {
+            if (Data[index].references.Any(reference => reference.gameObject is null))
+            {
+                if (EditorUtility.DisplayDialog(Data[index].name, "Selected game object collection contains invalid references, remove it from list?", "Yes", "No"))
+                {
+                    Remove(index);
+                }
+            }
+            else
+            {
+                Selection.objects = Data[index].references.Select(reference => reference.gameObject).ToArray();
+                SceneView.lastActiveSceneView.FrameSelected();
+            }
+        }
+
+        public void Remove(int index)
+        {
+            // foreach (var reference in Data[index].references)
+            // {
+            //     if (reference.gameObject is not null)
+            //     {
+            //         UnityEngine.Object.DestroyImmediate(reference.gameObject.GetComponent<GuidComponent>());
+            //     }
+            // }
+
+            Data.RemoveAt(index);
+            DataListView.Rebuild();
+            ChangeEvent?.Invoke();
+            if (IsEmpty) DataListView.style.display = DisplayStyle.None;
+            Bookmark4UnityWindow.UpdateSavedData();
+        }
+
+        public void RemoveAll()
+        {
+            // for (int i = 0; i < Data.Count; i++)
+            // {
+            //     foreach (var reference in Data[i].references)
+            //     {
+            //         if (reference.gameObject is not null)
+            //         {
+            //             UnityEngine.Object.DestroyImmediate(reference.gameObject.GetComponent<GuidComponent>());
+            //         }
+            //     }
+            // }
+
+            Data.Clear();
+            DataListView.Rebuild();
+            DataListView.style.display = DisplayStyle.None;
+        }
+
+        private void OnDrag(int index)
+        {
+            if (Event.current.type != EventType.MouseDrag || Data[index].references.Any(reference => reference.gameObject is null)) return;
+            DragAndDrop.PrepareStartDrag();
+            DragAndDrop.objectReferences = Data[index].references.Select(reference => reference.gameObject).ToArray();
+            DragAndDrop.StartDrag(Data[index].name);
+            Event.current.Use();
+        }
+
+        public void SortDesc()
+        {
+            Data.Sort((a, b) => a.name.CompareTo(b.name));
+            DataListView.RefreshItems();
+        }
+
+        public void SortAsc()
+        {
+            Data.Sort((a, b) => b.name.CompareTo(a.name));
+            DataListView.RefreshItems();
+        }
+
+        public IEnumerable<SceneObjectCollection> ToData()
+        {
+            return Data.Select(reference => reference.ToData());
+        }
+    }
+}

--- a/Assets/Bookmark4Unity/Editor/SceneObjectCollectionListView.cs.meta
+++ b/Assets/Bookmark4Unity/Editor/SceneObjectCollectionListView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b996993a24d6d40ca8cf393b539a79bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Bookmark4Unity/Editor/SceneObjectListView.cs
+++ b/Assets/Bookmark4Unity/Editor/SceneObjectListView.cs
@@ -1,0 +1,174 @@
+namespace Bookmark4Unity.Editor
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Bookmark4Unity.Guid;
+    using UnityEditor;
+    using UnityEngine;
+    using UnityEngine.UIElements;
+
+    public class SceneObjectListView
+    {
+        public event Action ChangeEvent;
+        public List<GuidReference> Data { get; private set; }
+        public ListView DataListView { get; private set; }
+        public const int ItemHeight = 15;
+        public bool IsEmpty => Data.Count < 1;
+        public Dictionary<int, EventCallback<ClickEvent>> pingActions = new();
+        public Dictionary<int, EventCallback<ClickEvent>> focusActions = new();
+        public Dictionary<int, EventCallback<ClickEvent>> delActions = new();
+        public Dictionary<int, EventCallback<PointerLeaveEvent>> dragActions = new();
+
+        public SceneObjectListView(List<GuidReference> data, VisualTreeAsset btnAsset)
+        {
+            Data = data;
+            DataListView = new(Data, ItemHeight, () =>
+            {
+                return btnAsset.Instantiate();
+            },
+            (item, i) =>
+            {
+                var icon = item.Q<Button>("Icon");
+                var btn = item.Q<Button>("Btn");
+                var focus = item.Q<Button>("Focus");
+                var del = item.Q<Button>("Del");
+                var data = Data[i];
+                var index = i; // save value for lambda functions
+                icon.style.backgroundImage = Background.FromTexture2D(
+                    data.gameObject is null ?
+                    EditorGUIUtility.IconContent("console.warnicon").image as Texture2D :
+                    PrefabUtility.GetIconForGameObject(data.gameObject));
+                focus.style.backgroundImage = Background.FromTexture2D(SceneViewBookmarkManager.SceneViewBookmarkIcon);
+                del.style.backgroundImage = Background.FromTexture2D(SceneViewBookmarkManager.SceneViewEmptyIcon);
+                btn.text = data.CachedName;
+
+                // ping
+                if (pingActions.ContainsKey(i)) btn.UnregisterCallback<ClickEvent>(pingActions[i]);
+                pingActions[i] = evt => Ping(index);
+                btn.RegisterCallback<ClickEvent>(pingActions[i]);
+                btn.tooltip = $"Select \"{data.CachedName}\"";
+
+                // focus
+                if (focusActions.ContainsKey(i)) focus.UnregisterCallback<ClickEvent>(focusActions[i]);
+                focusActions[i] = evt => Focus(index);
+                focus.RegisterCallback<ClickEvent>(focusActions[i]);
+                focus.tooltip = $"Focus on \"{data.CachedName}\"";
+
+                // del
+                if (delActions.ContainsKey(i)) del.UnregisterCallback<ClickEvent>(delActions[i]);
+                delActions[i] = evt => Remove(index);
+                del.RegisterCallback<ClickEvent>(delActions[i]);
+                del.tooltip = $"Unpin \"{data.CachedName}\"";
+
+                // drag
+                if (dragActions.ContainsKey(i)) btn.UnregisterCallback<PointerLeaveEvent>(dragActions[i]);
+                dragActions[i] = evt => OnDrag(index);
+                btn.RegisterCallback<PointerLeaveEvent>(dragActions[i]);
+            })
+            {
+                reorderable = true,
+                showBorder = false
+            };
+
+            DataListView.style.flexGrow = 1f; // Fills the window
+            DataListView.style.display = IsEmpty ? DisplayStyle.None : DisplayStyle.Flex;
+        }
+
+        public bool Add(GuidReference data)
+        {
+            if (Data.Contains(data)) return false;
+            Data.Add(data);
+            DataListView.Rebuild();
+            ChangeEvent?.Invoke();
+            DataListView.style.display = DisplayStyle.Flex;
+            return true;
+        }
+
+        public void Ping(int index)
+        {
+            if (Data[index].gameObject != null)
+            {
+                Selection.activeGameObject = Data[index].gameObject;
+            }
+            else
+            {
+                if (EditorUtility.DisplayDialog(Data[index].CachedName, "Selected game object does not exist on current scene, remove it from list?", "Yes", "No"))
+                {
+                    Remove(index);
+                }
+            }
+        }
+
+        public void Focus(int index)
+        {
+            if (Data[index].gameObject != null)
+            {
+                Selection.activeGameObject = Data[index].gameObject;
+                SceneView.lastActiveSceneView.FrameSelected();
+            }
+            else
+            {
+                if (EditorUtility.DisplayDialog(Data[index].CachedName, "Selected game object does not exist on current scene, remove it from list?", "Yes", "No"))
+                {
+                    Remove(index);
+                }
+            }
+        }
+
+        public void Remove(int index)
+        {
+            // if (Data[index].gameObject is not null)
+            // {
+            //     UnityEngine.Object.DestroyImmediate(Data[index].gameObject.GetComponent<GuidComponent>());
+            // }
+
+            Data.RemoveAt(index);
+            DataListView.Rebuild();
+            ChangeEvent?.Invoke();
+            if (IsEmpty) DataListView.style.display = DisplayStyle.None;
+            Bookmark4UnityWindow.UpdateSavedData();
+        }
+
+        public void RemoveAll()
+        {
+            // for (int i = 0; i < Data.Count; i++)
+            // {
+            //     if (Data[i].gameObject is not null)
+            //     {
+            //         UnityEngine.Object.DestroyImmediate(Data[i].gameObject.GetComponent<GuidComponent>());
+            //     }
+            // }
+
+            Data.Clear();
+            DataListView.Rebuild();
+            DataListView.style.display = DisplayStyle.None;
+        }
+
+        private void OnDrag(int index)
+        {
+            if (Event.current.type != EventType.MouseDrag || Data[index].gameObject is null) return;
+            DragAndDrop.PrepareStartDrag();
+            DragAndDrop.objectReferences = new UnityEngine.Object[] { Data[index].gameObject };
+            DragAndDrop.StartDrag(Data[index].CachedName);
+            Event.current.Use();
+        }
+
+        public void SortDesc()
+        {
+            Data.Sort((a, b) => a.CachedName.CompareTo(b.CachedName));
+            DataListView.RefreshItems();
+        }
+
+        public void SortAsc()
+        {
+            Data.Sort((a, b) => b.CachedName.CompareTo(a.CachedName));
+            DataListView.RefreshItems();
+        }
+
+        public IEnumerable<GuidData> ToData()
+        {
+            return Data.Select(reference => reference.ToData());
+        }
+    }
+}

--- a/Assets/Bookmark4Unity/Editor/SceneObjectListView.cs.meta
+++ b/Assets/Bookmark4Unity/Editor/SceneObjectListView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0bea6dca3cdf64be59942325257659bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Bookmark4Unity/Editor/Utility/EditorInputDialog.cs
+++ b/Assets/Bookmark4Unity/Editor/Utility/EditorInputDialog.cs
@@ -1,0 +1,109 @@
+namespace Bookmark4Unity.Editor
+{
+    using System;
+    using UnityEditor;
+    using UnityEngine;
+
+    /// <summary>
+    /// Modified Vedran_M's shared code.
+    /// https://forum.unity.com/threads/is-there-a-way-to-input-text-using-a-unity-editor-utility.473743/
+    /// </summary>
+    public class EditorInputDialog : EditorWindow
+    {
+        string description, inputText;
+        string okButton, cancelButton;
+        Action onOKButton;
+
+        bool shouldClose = false;
+
+        void OnGUI()
+        {
+            // Check if Esc/Return have been pressed
+            var e = Event.current;
+            if (e.type == EventType.KeyDown)
+            {
+                switch (e.keyCode)
+                {
+                    // Escape pressed
+                    case KeyCode.Escape:
+                        shouldClose = true;
+                        e.Use();
+                        break;
+
+                    // Enter pressed
+                    case KeyCode.Return:
+                    case KeyCode.KeypadEnter:
+                        onOKButton?.Invoke();
+                        shouldClose = true;
+                        e.Use();
+                        break;
+                }
+            }
+
+            if (shouldClose)
+            {  // Close this dialog
+                Close();
+            }
+
+            // Draw our control
+            var rect = EditorGUILayout.BeginVertical();
+
+            EditorGUILayout.Space(12);
+            EditorGUILayout.LabelField(description);
+
+            EditorGUILayout.Space(8);
+            GUI.SetNextControlName("inText");
+            inputText = EditorGUILayout.TextField("", inputText);
+            GUI.FocusControl("inText");   // Focus text field
+            EditorGUILayout.Space(12);
+
+            // Draw OK / Cancel buttons
+            var r = EditorGUILayout.GetControlRect();
+            r.width /= 2;
+            if (GUI.Button(r, okButton))
+            {
+                onOKButton?.Invoke();
+                shouldClose = true;
+            }
+
+            r.x += r.width;
+            if (GUI.Button(r, cancelButton))
+            {
+                inputText = null;   // Cancel - delete inputText
+                shouldClose = true;
+            }
+
+            EditorGUILayout.Space(8);
+            EditorGUILayout.EndVertical();
+
+            // Force change size of the window
+            if (rect.width != 0 && minSize != rect.size)
+            {
+                minSize = maxSize = rect.size;
+            }
+        }
+
+        /// <summary>
+        /// Returns text player entered, or null if player cancelled the dialog.
+        /// </summary>
+        /// <param name="title"></param>
+        /// <param name="description"></param>
+        /// <param name="inputText"></param>
+        /// <param name="okButton"></param>
+        /// <param name="cancelButton"></param>
+        /// <returns>input string</returns>
+        public static string Show(string title, string description, string inputText, string okButton = "OK", string cancelButton = "Cancel")
+        {
+            string ret = null;
+            var window = CreateInstance<EditorInputDialog>();
+            window.titleContent = new GUIContent(title);
+            window.description = description;
+            window.inputText = inputText;
+            window.okButton = okButton;
+            window.cancelButton = cancelButton;
+            window.onOKButton += () => ret = window.inputText;
+            window.ShowModalUtility();
+            return ret;
+        }
+    }
+}

--- a/Assets/Bookmark4Unity/Editor/Utility/EditorInputDialog.cs.meta
+++ b/Assets/Bookmark4Unity/Editor/Utility/EditorInputDialog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f97ce7a9d7ce433e86daeddf1466dae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Bookmark4Unity/package.json
+++ b/Assets/Bookmark4Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.superkerokero.bookmark4unity",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "displayName": "Bookmark4Unity",
   "description": "A simple unity editor tool to provide basic bookmarking for scene objects, scene view camera positions, and project assets.",
   "unity": "2021.3",

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -234,7 +234,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dce4739fafe49447fb80c1405f714179, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  serializedGuid: 97fd4722c1f14e4d8eb566552231598a
+  serializedGuid: 2387ee7a2f71854b864dd1eba7f4ae6c
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -245,6 +245,7 @@ GameObject:
   m_Component:
   - component: {fileID: 705507995}
   - component: {fileID: 705507994}
+  - component: {fileID: 705507996}
   m_Layer: 0
   m_Name: Directional Light
   m_TagString: Untagged
@@ -329,6 +330,19 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &705507996
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705507993}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dce4739fafe49447fb80c1405f714179, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  serializedGuid: e37a7eb8ef26f4428650d53de4b46220
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -340,6 +354,7 @@ GameObject:
   - component: {fileID: 963194228}
   - component: {fileID: 963194227}
   - component: {fileID: 963194226}
+  - component: {fileID: 963194229}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -413,3 +428,16 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &963194229
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dce4739fafe49447fb80c1405f714179, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  serializedGuid: 53db4b99d8e4094a86710864cab59d12

--- a/Assets/Scenes/SampleScene2.unity
+++ b/Assets/Scenes/SampleScene2.unity
@@ -233,7 +233,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dce4739fafe49447fb80c1405f714179, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  serializedGuid: 99bc35c5533e5f4ca5399dd06fbfd5fb
+  serializedGuid: 85c5483297ade349bde4e6e37c6c0c1f
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -341,7 +341,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dce4739fafe49447fb80c1405f714179, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  serializedGuid: d86a831e14d1304ab6f1825edd6212b0
+  serializedGuid: db59c90f3535214693eb16a812f632eb
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -439,4 +439,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dce4739fafe49447fb80c1405f714179, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  serializedGuid: c4afd6e17a3e2d40b27d68fae6fa3fa3
+  serializedGuid: 72d7931b0c029642833ee820330dc514


### PR DESCRIPTION
### Features

- Added scene object collection bookmarking.
  - When pinning multiple scene objects, you will be asked to either create a collection of scene objects or add scene object bookmarks individually.
- Guid components will not be removed automatically when un-pinning scene object bookmarks to avoid making bookmark collections invalid.
  - If you want to remove all guid components in loaded scenes, use `Bookmark4Unity Window → Clear → All Guid Components Attached`. Note that removing guid components will make scene object bookmarks invalid.

### Bugfix

- Fix a typo in scene objects editor dialogue.